### PR TITLE
Fixing opt-in exploit vulnerability in manager contract

### DIFF
--- a/backend/nft_market/contracts/assets/manager.py
+++ b/backend/nft_market/contracts/assets/manager.py
@@ -25,17 +25,9 @@ class ManagerContract:
     def on_register(self):
         return Seq(
             [
-                # Set default values for user
-                If(
-                    Global.group_size() == Int(1),
-                    Seq(
-                        [
-                            self.bid_price.put(Int(0)),
-                            Return(Int(1)),
-                        ]
-                    ),
-                    Return(Int(0)),
-                )
+                Assert(Global.group_size() == Int(1)),
+                self.bid_price.put(Int(0)),
+                Return(Int(1)),
             ]
         )
 

--- a/backend/nft_market/contracts/assets/manager.py
+++ b/backend/nft_market/contracts/assets/manager.py
@@ -26,8 +26,16 @@ class ManagerContract:
         return Seq(
             [
                 # Set default values for user
-                self.bid_price.put(Int(0)),
-                Return(Int(1)),
+                If(
+                    Global.group_size() == Int(1),
+                    Seq(
+                        [
+                            self.bid_price.put(Int(0)),
+                            Return(Int(1)),
+                        ]
+                    ),
+                    Return(Int(0)),
+                )
             ]
         )
 


### PR DESCRIPTION
The on_register function in manager contract does not verify the length of atomic transaction. Hence, it is possible to craft such atomic transaction that could steal money or assets from the escrow since first transaction in atomic group will automatically be approved and this will auto approve all remaining transactions in atomic group. 

Solution introduces an extra conditional that simply checks the size of the group. 