### PR TITLE
Prevent opting-in twice

### DIFF
--- a/backend/nft_market/contracts/assets/manager.py
+++ b/backend/nft_market/contracts/assets/manager.py
@@ -26,7 +26,7 @@ class ManagerContract:
         return Seq(
             [
                 # Prevent opting-in for opted-in users
-                Assert(Not(App.optedIn(Int(0), Int(0))),
+                Assert(Not(App.optedIn(Txn.accounts[0], Txn.applications[0]))),
                 # Set default values for user
                 self.bid_price.put(Int(0)),
                 Return(Int(1)),

--- a/backend/nft_market/contracts/assets/manager.py
+++ b/backend/nft_market/contracts/assets/manager.py
@@ -25,6 +25,8 @@ class ManagerContract:
     def on_register(self):
         return Seq(
             [
+                # Prevent opting-in for opted-in users
+                Assert(Not(App.optedIn(Int(0), Int(0))),
                 # Set default values for user
                 self.bid_price.put(Int(0)),
                 Return(Int(1)),


### PR DESCRIPTION
Prevent the user opting-in twice to forfeit their bid (by accident for example).

Requires TEALv4 (the parameters for appoptedin can be changed to work with TEALv3 if needed)